### PR TITLE
Adds the `prefix` from the Tailwind config to the `dark` class

### DIFF
--- a/src/withGlobals.js
+++ b/src/withGlobals.js
@@ -15,10 +15,11 @@ export const withGlobals = (StoryFn, context) => {
 };
 
 const changeBackgroundMode = (selector, state) => {
+  const [{ prefix }] = useGlobals();
   const rootElement = document.getElementById(selector);
   if (state.darkMode) {
-    rootElement.classList.add('m-dark');
+    rootElement.classList.add(`${prefix}dark`);
   } else {
-    rootElement.classList.remove('m-dark')
+    rootElement.classList.remove(`${prefix}dark`)
   }
 }

--- a/src/withGlobals.js
+++ b/src/withGlobals.js
@@ -17,8 +17,8 @@ export const withGlobals = (StoryFn, context) => {
 const changeBackgroundMode = (selector, state) => {
   const rootElement = document.getElementById(selector);
   if (state.darkMode) {
-    rootElement.classList.add('dark');
+    rootElement.classList.add('m-dark');
   } else {
-    rootElement.classList.remove('dark')
+    rootElement.classList.remove('m-dark')
   }
 }


### PR DESCRIPTION
Noticed when I tried to use this with my Tailwind config the `dark` class wasn't receiving our locally set prefix meaning it wouldn't work. Tried to update the component to include the prefix automatically if the person has already set one in their config.