### PR TITLE
chore: add react 18 support 

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@storybook/components": "^6.2.9",
     "@storybook/core-events": "^6.2.9",
     "@storybook/theming": "^6.2.9",
-    "react": "^16.8.0 || ^17.0.0",
+    "react": "^16.8.0 || ^17.0.0" || "^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@storybook/components": "^6.2.9",
     "@storybook/core-events": "^6.2.9",
     "@storybook/theming": "^6.2.9",
-    "react": "^16.8.0 || ^17.0.0" || "^18.0.0",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Based on commit https://github.com/renatomoor/storybook-tailwind-dark-mode/commit/1b7b71541d72cfa082bcbb447fd4e86c0c99e96a I now added `react@18` support.

Fixes https://github.com/renatomoor/storybook-tailwind-dark-mode/issues/10