### PR TITLE
Add compatibility with storybook 7.0.0 and onwards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,11 +27,11 @@
         "storybook": "^7.0.5"
       },
       "peerDependencies": {
-        "@storybook/addons": "^7.0.5",
-        "@storybook/api": "^7.0.5",
-        "@storybook/components": "^7.0.5",
-        "@storybook/core-events": "^7.0.5",
-        "@storybook/theming": "^7.0.5",
+        "@storybook/addons": "^7.0.0",
+        "@storybook/api": "^7.0.0",
+        "@storybook/components": "^7.0.0",
+        "@storybook/core-events": "^7.0.0",
+        "@storybook/theming": "^7.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -55,11 +55,11 @@
     "storybook": "^7.0.5"
   },
   "peerDependencies": {
-    "@storybook/addons": "^7.0.5",
-    "@storybook/api": "^7.0.5",
-    "@storybook/components": "^7.0.5",
-    "@storybook/core-events": "^7.0.5",
-    "@storybook/theming": "^7.0.5",
+    "@storybook/addons": "^7.0.0",
+    "@storybook/api": "^7.0.0",
+    "@storybook/components": "^7.0.0",
+    "@storybook/core-events": "^7.0.0",
+    "@storybook/theming": "^7.0.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.19-canary.17.9307a98.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-tailwind-dark-mode@1.0.19-canary.17.9307a98.0
  # or 
  yarn add storybook-tailwind-dark-mode@1.0.19-canary.17.9307a98.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
