### PR TITLE
fix: use html instead of #storybook-root as class selector

### DIFF
--- a/src/withGlobals.js
+++ b/src/withGlobals.js
@@ -11,7 +11,7 @@ export const withGlobals = (StoryFn, context) => {
   useEffect(() => {
     const selector = isInDocs
       ? `#anchor--${context.id} .sb-story`
-      : "#storybook-root";
+      : "html";
 
     console.log(globals);
 


### PR DESCRIPTION
This allows us to use this custom preview body and have true dark mode:

`.storybook/preview-body.html`
```
<body class="dark:bg-slate-900"></body>
```